### PR TITLE
hotfix: Prevent crash in Entries tab by replacing Calendar

### DIFF
--- a/app/(tabs)/entries.tsx
+++ b/app/(tabs)/entries.tsx
@@ -45,11 +45,17 @@ export default function EntriesScreen() {
       const start = dayjs(entry.start_ts);
       setStartHour(start.hour().toString());
       setStartMinute(start.minute().toString());
+    } else {
+      setStartHour("0");
+      setStartMinute("0");
     }
     if (entry.end_ts) {
       const end = dayjs(entry.end_ts);
       setEndHour(end.hour().toString());
       setEndMinute(end.minute().toString());
+    } else {
+      setEndHour("0");
+      setEndMinute("0");
     }
     setModalVisible(true);
   };
@@ -144,14 +150,9 @@ export default function EntriesScreen() {
         <View style={styles.modalContainer}>
           <View style={styles.modalView}>
             {!selectedDate ? (
-              <Calendar
-                onDayPress={(day) => {
-                  setSelectedDate(day.dateString);
-                }}
-                markedDates={{
-                  [selectedDate]: { selected: true, disableTouchEvent: true, selectedColor: 'blue' }
-                }}
-              />
+              <TouchableOpacity onPress={() => setSelectedDate(dayjs().format('YYYY-MM-DD'))}>
+                <Text>Select a date</Text>
+              </TouchableOpacity>
             ) : (
               <>
                 <Text>{t('selectedDate', { date: selectedDate })}</Text>

--- a/components/icons.tsx
+++ b/components/icons.tsx
@@ -32,6 +32,9 @@ export const Check         = (p: P) => <Feather name="check" {...p} />;
 export const Download      = (p: P) => <Feather name="download" {...p} />;
 export const FileText      = (p: P) => <Feather name="file-text" {...p} />;
 export const Globe         = (p: P) => <Feather name="globe" {...p} />;
+export const Plus          = (p: P) => <Feather name="plus" {...p} />;
+export const Trash         = (p: P) => <Feather name="trash-2" {...p} />;
+export const Edit          = (p: P) => <Feather name="edit" {...p} />;
 
 // default export so accidental `import Icons from '@/components/icons'` still works
 const Icons = {
@@ -40,6 +43,6 @@ const Icons = {
   LogIn, LogOut, RefreshCw,
   FileSpreadsheet, Database, Play,
   Save, Clock, RotateCcw, Check, Download, FileText,
-  Globe,
+  Globe, Plus, Trash, Edit,
 };
 export default Icons;


### PR DESCRIPTION
This commit provides a hotfix to address a critical bug that caused the Entries tab to show a blank screen, even after previous fixes.

The root cause has been isolated to the `react-native-calendars` component. To restore functionality to the app immediately, the `Calendar` component has been temporarily replaced with a simple `TouchableOpacity` that allows the user to select the current date.

This is a temporary measure to prevent the app from crashing. The underlying issue with the `react-native-calendars` library needs further investigation, which is not possible in the current environment. This change ensures that users can still add, edit, and delete entries.